### PR TITLE
Make APPLICATION_EXTENSION_API_ONLY YES on macOS environment

### DIFF
--- a/Default.xcodeproj/project.pbxproj
+++ b/Default.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		AA93C4541F98813A00BCFA03 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -555,6 +556,7 @@
 		AA93C4551F98813A00BCFA03 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;


### PR DESCRIPTION
I'm writing a Safari extension application with this framework on the macOS environment, and to use it for App Extension `APPLICATION_EXTENSION_API_ONLY` option needs to be `YES`. So, I've changed it to `YES` on the macOS environment.